### PR TITLE
Fix/supports aws config

### DIFF
--- a/examples/ethers/README.md
+++ b/examples/ethers/README.md
@@ -7,8 +7,17 @@ If you don't have `TOKEN_ADDRESS` yet, please run [Truffle example]()
 1. `$ npm install`
 2. Create `.env`:
 ```
+# Original
 KEYID=your key id
 INFURAKEY=your infura API key
+TOKEN_ADDRESS=KMS Token address
+
+# New
+KEYID=your key id
+PROVIDER=your provider url
+ACCESSKEYID=your aws access key id
+SECRETACCESSKEY=your aws secrect access key
+REGION=your aws service region
 TOKEN_ADDRESS=KMS Token address
 ```
 3. `$ npm start`

--- a/examples/ethers/index.ts
+++ b/examples/ethers/index.ts
@@ -10,7 +10,10 @@ const getSigner = async () => {
     console.log('Initiating KMSProvider...')
     const kmsProvider = new KMSProvider({
       keyId: process.env.KEYID,
-      providerOrUrl: 'wss://ropsten.infura.io/ws/v3/' + process.env.INFURAKEY
+      providerOrUrl: process.env.PROVIDER,
+      accessKeyId: process.env.ACCESSKEYID,
+      secretAccessKey: process.env.SECRETACCESSKEY,
+      region: process.env.REGION
     })
 
     console.log('KMSProvider initialized')

--- a/examples/truffle/README.md
+++ b/examples/truffle/README.md
@@ -6,8 +6,16 @@
 1. `$ npm install`
 2. Create `.env`:
 ```
+# Original
 KEYID=your key id
 INFURAKEY=your infura API key
+
+# New
+KEYID=your key id
+PROVIDER=your provider url
+ACCESSKEYID=your aws access key id
+SECRETACCESSKEY=your aws secrect access key
+REGION=your aws service region
 ```
 3. `$ npm run compile`
 4. `$ npm run migrate -- --network ropsten`

--- a/examples/truffle/truffle-config.js
+++ b/examples/truffle/truffle-config.js
@@ -10,12 +10,13 @@ module.exports = {
       provider: () =>
         new KMSProvider({
           keyId: process.env.KEYID,
-          providerOrUrl:
-            'wss://ropsten.infura.io/ws/v3/' + process.env.INFURAKEY
+          providerOrUrl: process.env.PROVIDER,
+          accessKeyId: process.env.ACCESSKEYID,
+          secretAccessKey: process.env.SECRETACCESSKEY,
+          region: process.env.REGION
         }),
       network_id: 3,
       confirmations: 2,
-      timeoutBlocks: 200,
       skipDryRun: true
     }
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rm -rf dist && tsc",
-    "prepublish": "tsc"
+    "prepublish": "tsc",
+    "postinstall": "tsc"
   },
   "repository": {
     "type": "git",

--- a/src/kms.ts
+++ b/src/kms.ts
@@ -1,5 +1,5 @@
-import { KMS } from 'aws-sdk'
-import { SignParams } from './types'
+import { KMS, AWSError } from 'aws-sdk'
+import { SignParams, PromiseResult } from './types'
 import { getEthAddressFromPublicKey } from './eth'
 
 export const kms = (
@@ -20,7 +20,8 @@ export const getPublicKey = (
   accessKeyId: string,
   secretAccessKey: string,
   region: string
-) => kms(accessKeyId, secretAccessKey, region).getPublicKey({ KeyId }).promise()
+): Promise<PromiseResult<KMS.GetPublicKeyResponse, AWSError>> =>
+  kms(accessKeyId, secretAccessKey, region).getPublicKey({ KeyId }).promise()
 
 export const getEthAddressFromKMS = async (
   keyId: KMS.GetPublicKeyRequest['KeyId'],
@@ -38,7 +39,7 @@ export const sign = (
   accessKeyId: string,
   secretAccessKey: string,
   region: string
-) => {
+): Promise<PromiseResult<KMS.SignResponse, AWSError>> => {
   const { keyId, message } = signParams
 
   return kms(accessKeyId, secretAccessKey, region)

--- a/src/kms.ts
+++ b/src/kms.ts
@@ -2,23 +2,46 @@ import { KMS } from 'aws-sdk'
 import { SignParams } from './types'
 import { getEthAddressFromPublicKey } from './eth'
 
-export const kms = new KMS()
+export const kms = (
+  accessKeyId: string,
+  secretAccessKey: string,
+  region: string
+): KMS => {
+  return new KMS({
+    accessKeyId: accessKeyId,
+    secretAccessKey: secretAccessKey,
+    region: region,
+    apiVersion: 'latest'
+  })
+}
 
-export const getPublicKey = (KeyId: KMS.GetPublicKeyRequest['KeyId']) =>
-  kms.getPublicKey({ KeyId }).promise()
+export const getPublicKey = (
+  KeyId: KMS.GetPublicKeyRequest['KeyId'],
+  accessKeyId: string,
+  secretAccessKey: string,
+  region: string
+) => kms(accessKeyId, secretAccessKey, region).getPublicKey({ KeyId }).promise()
 
 export const getEthAddressFromKMS = async (
-  keyId: KMS.GetPublicKeyRequest['KeyId']
+  keyId: KMS.GetPublicKeyRequest['KeyId'],
+  accessKeyId: string,
+  secretAccessKey: string,
+  region: string
 ) => {
-  const KMSKey = await getPublicKey(keyId)
+  const KMSKey = await getPublicKey(keyId, accessKeyId, secretAccessKey, region)
 
   return getEthAddressFromPublicKey(KMSKey.PublicKey)
 }
 
-export const sign = (signParams: SignParams) => {
+export const sign = (
+  signParams: SignParams,
+  accessKeyId: string,
+  secretAccessKey: string,
+  region: string
+) => {
   const { keyId, message } = signParams
 
-  return kms
+  return kms(accessKeyId, secretAccessKey, region)
     .sign({
       KeyId: keyId,
       Message: message,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { KMS } from 'aws-sdk'
+import { KMS, Response } from 'aws-sdk'
 import Common, { CommonOpts } from '@ethereumjs/common'
 
 export type SignParams = {
@@ -25,3 +25,5 @@ export type KMSProviderConstructor = {
   pollingInterval?: number
   chainSettings?: ChainSettings
 }
+
+export type PromiseResult<D, E> = D & { $response: Response<D, E> }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,9 @@ export type ChainSettings = Omit<CommonOpts, 'chain'> & {
 
 export type KMSProviderConstructor = {
   keyId: KMS.KeyIdType
+  accessKeyId: string
+  secretAccessKey: string
+  region: string
   providerOrUrl: string
   shareNonce?: boolean
   pollingInterval?: number


### PR DESCRIPTION
Hi,

When I tested, I found the error that indicates the region setting is missing.

```bash
RuntimeError: abort(ConfigError: Missing region in config). Build with -s ASSERTIONS=1 for more info.
...
```

So, I tried to add more parameters for the KMS constructor, and the final result like

```bash
	new KMSProvider({
          keyId: process.env.KEYID,
          providerOrUrl: process.env.PROVIDER,
          accessKeyId: process.env.ACCESSKEYID,
          secretAccessKey: process.env.SECRETACCESSKEY,
          region: process.env.REGION
        }),
```

For the test result, please check
https://ropsten.etherscan.io/address/0x2055bf3a9cfb656fa1f39695c7850f854aec7554

It needs more settings on testing in package.json.
https://github.com/krgko/eth-signer-kms/tree/test/support_aws_config